### PR TITLE
Updated to use new prefixes

### DIFF
--- a/templates/scaffold/layouts/menu_template.stub
+++ b/templates/scaffold/layouts/menu_template.stub
@@ -1,3 +1,3 @@
 <li class="{{ Request::is('$MODEL_NAME_PLURAL_CAMEL$*') ? 'active' : '' }}">
-    <a href="{!! route('$ROUTE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index') !!}">$MODEL_NAME_PLURAL$</a>
+    <a href="{!! route('$ROUTE_PREFIX$.$MODEL_NAME_PLURAL_CAMEL$.index') !!}">$MODEL_NAME_PLURAL$</a>
 </li>


### PR DESCRIPTION
$ROUTE_PREFIX$  ex: admin.? uses
$VIEW_PREFIX$  in: backend  :example views directory
